### PR TITLE
Feature/things to do#5

### DIFF
--- a/backend/routes/thingsToDoLists.js
+++ b/backend/routes/thingsToDoLists.js
@@ -105,8 +105,8 @@ router.delete("/:listId/tag/remove/:tagId", expressAsyncHandler( async (req, res
     try {
         const thingsToDoListTagAss = await db.ThingsToDoListTagJoins.findOne({
             where: {
-                thingToDoListId: parseInt(req.params.listId),
-                thingToDoListTagId: parseInt(req.params.tagId)
+                thingsToDoListId: parseInt(req.params.listId),
+                thingsToDoListTagId: parseInt(req.params.tagId)
             }
         })
     

--- a/backend/routes/thingsToDoLists.js
+++ b/backend/routes/thingsToDoLists.js
@@ -100,7 +100,27 @@ router.post("/:id/add-thing-to-do", expressAsyncHandler(async (req, res) => {
 }));
 
 //handles only removing existing tags to the list
-
+router.delete("/:listId/tag/remove/:tagId", expressAsyncHandler( async (req, res, next) => {
+    // get the connection that represents the tag being associated with the list
+    try {
+        const thingsToDoListTagAss = await db.ThingsToDoListTagJoins.findOne({
+            where: {
+                thingToDoListId: parseInt(req.params.listId),
+                thingToDoListTagId: parseInt(req.params.tagId)
+            }
+        })
+    
+        if (thingsToDoListTagAss) {
+            await thingsToDoListTagAss.destroy()
+            await res.json({message: "resource deleted"})
+        } else {
+            res.status(500).json({message: "resource could not be found"})
+        }
+    
+    } catch (e) {
+        next(e)
+    }
+}))
 //handles only adding new thingsToDo to the list
 
 //handles only removing existing thingsToDo from the list


### PR DESCRIPTION
Details:
- Added a route that will only remove a singular tag to a "thing to do" list
- Noted in a comment that security for this route will need to be added. This will work for anyone but will need to be modified to only work with the user that is associated with the list. Will need to check through bearer token sent back to the API